### PR TITLE
Added help page for NotificationTriggers documentation

### DIFF
--- a/Utilities.Games/Pages/Help/Index.razor
+++ b/Utilities.Games/Pages/Help/Index.razor
@@ -1,0 +1,10 @@
+﻿@page "/help"
+
+<h3>Help</h3>
+<p class="alert alert-light">Here is a list of helpful topics that will enable you to get the most out of this site.</p>
+
+<ul>
+    <li>
+        <a href="./help/notification-triggers">Notification Triggers</a>
+    </li>
+</ul>

--- a/Utilities.Games/Pages/Help/NotificationTriggers.razor
+++ b/Utilities.Games/Pages/Help/NotificationTriggers.razor
@@ -1,0 +1,5 @@
+﻿@page "/help/notification-triggers"
+<h3>Notification Triggers</h3>
+<p>Some subsites implement a feature for scheduled reminders. This feature relies on an experimental API available in Chrome browsers. Because it is experimental, users will have to enable this browser feature before it can be utilized by this site. To learn more about the Notifications API, visit <a href="https://web.dev/notification-triggers/" target="_blank">web.dev/notification-triggers</a>.</p>
+<p>To enable Notification Triggers, you must go to <code>chrome://flags</code> in your browser and search for the <code>#enable-experimental-web-platform-features</code> feature. Or try copying this address: <a href="chrome://flags/#enable-experimental-web-platform-features" target="_blank">chrome://flags/#enable-experimental-web-platform-features</a>.</p>
+<p>Once enabled, you may be prompted by the site the first time you try to create a new reminder if you wish to receive notifications. Simply agree to this prompt, but you may need to add your reminder again if it doesn't appear in the interface.</p>

--- a/Utilities.Games/Shared/NavMenu.razor
+++ b/Utilities.Games/Shared/NavMenu.razor
@@ -12,6 +12,11 @@
                 <span class="oi oi-home" aria-hidden="true"></span> Home
             </NavLink>
         </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="help" Match="NavLinkMatch.All">
+                <span class="oi oi-question-mark" aria-hidden="true"></span> Help
+            </NavLink>
+        </li>
     </ul>
 </div>
 


### PR DESCRIPTION
 - Added Help page to maintain list of help topics
 - Added Notification Triggers help topic to guide users through the process of enabling the experimental Notification Triggers API