### PR TITLE
Added help description for NotificationTriggers

### DIFF
--- a/Utilities.Games/Pages/Subsites/LOTR_RiseToWar/UserServerView.razor
+++ b/Utilities.Games/Pages/Subsites/LOTR_RiseToWar/UserServerView.razor
@@ -119,7 +119,7 @@
     }
     else
     {
-        <p class="alert alert-warning">Scheduled notifications are not supported in this browser.</p>
+        <p class="alert alert-warning">Scheduled notifications are not supported in this browser. Go to <a href="./help/notification-triggers">Help -> Notification Triggers</a> for more information on how you may be able to enable this feature.</p>
     }
 
     <hr />


### PR DESCRIPTION
Added help description in the event that the user's browser does not support Notification Triggers. The description contains a link to the new help page.